### PR TITLE
Disabled Beta Deposits

### DIFF
--- a/apps/app/messages/en.json
+++ b/apps/app/messages/en.json
@@ -284,9 +284,5 @@
       "negativeNumber": "Enter a positive number",
       "tooManyDecimals": "Too many decimals"
     }
-  },
-  "Beta": {
-    "beta": "Beta",
-    "learnMore": "Learn more on the gov forum"
   }
 }

--- a/apps/app/src/components/BetaBanner.tsx
+++ b/apps/app/src/components/BetaBanner.tsx
@@ -1,6 +1,5 @@
 import { ExternalLink } from '@shared/ui'
 import classNames from 'classnames'
-import { useTranslations } from 'next-intl'
 
 interface BetaBannerProps {
   className?: string
@@ -8,8 +7,6 @@ interface BetaBannerProps {
 
 export const BetaBanner = (props: BetaBannerProps) => {
   const { className } = props
-
-  const t = useTranslations('Beta')
 
   return (
     <div
@@ -19,13 +16,11 @@ export const BetaBanner = (props: BetaBannerProps) => {
       )}
     >
       <span className='px-1 font-grotesk font-semibold leading-5 text-red-600 border border-current rounded-[0.2rem]'>
-        {t('beta').toUpperCase()}
+        BETA
       </span>
-      <ExternalLink
-        href='https://gov.pooltogether.com/t/v5-private-beta-launch-information/3021'
-        size='sm'
-      >
-        {t('learnMore')}
+      <ExternalLink href='https://app.cabana.fi' size='sm'>
+        🚀 The public app has been launched! Migrate any Beta funds to the new and improved
+        deployment.
       </ExternalLink>
     </div>
   )

--- a/shared/react-components/components/Buttons/DepositButton.tsx
+++ b/shared/react-components/components/Buttons/DepositButton.tsx
@@ -1,7 +1,6 @@
 import { Vault } from '@generationsoftware/hyperstructure-client-js'
-import { useSelectedVault } from '@generationsoftware/hyperstructure-react-hooks'
-import { MODAL_KEYS, useIsModalOpen } from '@shared/generic-react-hooks'
-import '@shared/ui'
+// import { useSelectedVault } from '@generationsoftware/hyperstructure-react-hooks'
+// import { MODAL_KEYS, useIsModalOpen } from '@shared/generic-react-hooks'
 import { Button, ButtonProps } from '@shared/ui'
 import classNames from 'classnames'
 
@@ -12,18 +11,24 @@ interface DepositButtonProps extends Omit<ButtonProps, 'onClick'> {
 export const DepositButton = (props: DepositButtonProps) => {
   const { vault, children, className, ...rest } = props
 
-  const { setIsModalOpen } = useIsModalOpen(MODAL_KEYS.deposit)
+  // const { setIsModalOpen } = useIsModalOpen(MODAL_KEYS.deposit)
 
-  const { setSelectedVaultById } = useSelectedVault()
+  // const { setSelectedVaultById } = useSelectedVault()
 
-  const handleClick = () => {
-    setSelectedVaultById(vault.id)
-    setIsModalOpen(true)
-  }
+  // const handleClick = () => {
+  //   setSelectedVaultById(vault.id)
+  //   setIsModalOpen(true)
+  // }
 
   return (
-    <Button onClick={handleClick} className={classNames('w-24', className)} {...rest}>
+    <Button className={classNames('w-24', className)} {...rest} disabled={true}>
       {children ?? 'Deposit'}
     </Button>
   )
+
+  // return (
+  //   <Button onClick={handleClick} className={classNames('w-24', className)} {...rest}>
+  //     {children ?? 'Deposit'}
+  //   </Button>
+  // )
 }

--- a/shared/react-components/components/Buttons/LensterShareButton.tsx
+++ b/shared/react-components/components/Buttons/LensterShareButton.tsx
@@ -1,5 +1,4 @@
 import { Intl } from '@shared/types'
-import '@shared/ui'
 import { Button, ButtonProps } from '@shared/ui'
 
 interface LensterShareButtonProps extends Omit<ButtonProps, 'onClick' | 'href' | 'target'> {

--- a/shared/react-components/components/Buttons/TwitterShareButton.tsx
+++ b/shared/react-components/components/Buttons/TwitterShareButton.tsx
@@ -1,5 +1,4 @@
 import { Intl } from '@shared/types'
-import '@shared/ui'
 import { Button, ButtonProps } from '@shared/ui'
 
 interface TwitterShareButtonProps extends Omit<ButtonProps, 'onClick' | 'href' | 'target'> {


### PR DESCRIPTION
This PR disables the `Deposit` button throughout the `beta.cabana.fi` app, as well as updated the top banner to point to the new `app.cabana.fi`.

This PR should only be merged in once the new app is live.