### PR TITLE
Deposit With Permit TXs

### DIFF
--- a/packages/hyperstructure-react-hooks/package.json
+++ b/packages/hyperstructure-react-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@generationsoftware/hyperstructure-react-hooks",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "license": "MIT",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/hyperstructure-react-hooks/src/signatures/useApproveSignature.ts
+++ b/packages/hyperstructure-react-hooks/src/signatures/useApproveSignature.ts
@@ -1,6 +1,6 @@
 import { Vault } from '@generationsoftware/hyperstructure-client-js'
 import { EIP2612_PERMIT_TYPES, getSecondsSinceEpoch, OLD_DAI_PERMIT_TYPES } from '@shared/utilities'
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { Address, TypedDataDomain, verifyTypedData, zeroAddress } from 'viem'
 import { useAccount, useSignTypedData } from 'wagmi'
 import { useTokenNonces, useTokenPermitSupport, useTokenVersion, useVaultTokenData } from '..'
@@ -95,32 +95,7 @@ export const useApproveSignature = (
     }
   }, [tokenPermitSupport])
 
-  const {
-    data: signature,
-    isLoading: isWaiting,
-    isSuccess,
-    isError: isSigningError,
-    signTypedData
-  } = useSignTypedData({
-    domain,
-    message,
-    types,
-    primaryType: 'Permit'
-  })
-
-  const _signTypedData = () => {
-    if (tokenPermitSupport === 'eip2612') {
-      setDeadline(message.deadline as bigint)
-    } else if (tokenPermitSupport === 'daiPermit') {
-      setDeadline(message.expiry as bigint)
-    }
-    signTypedData()
-  }
-
-  const verifySignature = async (
-    sigToVerify: `0x${string}`,
-    callbacks?: { onSuccess?: (sig: `0x${string}`) => void; onError?: () => void }
-  ) => {
+  const verifySignature = async (sigToVerify: `0x${string}`) => {
     setIsInvalidSignature(false)
 
     const isValid = await verifyTypedData({
@@ -133,26 +108,38 @@ export const useApproveSignature = (
     })
 
     if (isValid) {
-      callbacks?.onSuccess?.(sigToVerify)
+      options?.onSuccess?.(sigToVerify)
       return true
     } else {
       setIsInvalidSignature(true)
-      callbacks?.onError?.()
+      options?.onError?.()
       return false
     }
   }
 
-  useEffect(() => {
-    if (!!signature && isSuccess) {
-      verifySignature(signature)
-    }
-  }, [isSuccess])
+  const {
+    data: signature,
+    isLoading: isWaiting,
+    isSuccess: isSigningSuccess,
+    isError: isSigningError,
+    signTypedData
+  } = useSignTypedData({
+    domain,
+    message,
+    types,
+    primaryType: 'Permit',
+    onSuccess: verifySignature,
+    onError: options?.onError
+  })
 
-  useEffect(() => {
-    if (isSigningError) {
-      options?.onError?.()
+  const _signTypedData = () => {
+    if (tokenPermitSupport === 'eip2612') {
+      setDeadline(message.deadline as bigint)
+    } else if (tokenPermitSupport === 'daiPermit') {
+      setDeadline(message.expiry as bigint)
     }
-  }, [isSigningError])
+    signTypedData()
+  }
 
   const enabled =
     !!userAddress &&
@@ -168,6 +155,7 @@ export const useApproveSignature = (
   const signApprove = enabled ? _signTypedData : undefined
 
   const isError = isSigningError || isInvalidSignature
+  const isSuccess = isSigningSuccess && !isError
 
   return { signature, deadline, isWaiting, isSuccess, isError, signApprove }
 }

--- a/shared/react-components/components/Modals/DepositModal/Views/MainView.tsx
+++ b/shared/react-components/components/Modals/DepositModal/Views/MainView.tsx
@@ -1,9 +1,14 @@
 import { PrizePool, Vault } from '@generationsoftware/hyperstructure-client-js'
-import { useVaultShareData } from '@generationsoftware/hyperstructure-react-hooks'
+import {
+  useTokenPermitSupport,
+  useVaultShareData,
+  useVaultTokenData
+} from '@generationsoftware/hyperstructure-react-hooks'
 import { Intl } from '@shared/types'
 import { Spinner } from '@shared/ui'
 import { getNiceNetworkNameByChainId } from '@shared/utilities'
 import { useAtomValue } from 'jotai'
+import { Address } from 'viem'
 import { PrizePoolBadge } from '../../../Badges/PrizePoolBadge'
 import { DepositForm, depositFormShareAmountAtom } from '../../../Form/DepositForm'
 import { NetworkFees, NetworkFeesProps } from '../../NetworkFees'
@@ -26,11 +31,22 @@ export const MainView = (props: MainViewProps) => {
   const { vault, prizePool, intl } = props
 
   const { data: shareData } = useVaultShareData(vault)
+  const { data: tokenData } = useVaultTokenData(vault)
+
+  const { data: tokenPermitSupport } = useTokenPermitSupport(
+    tokenData?.chainId as number,
+    tokenData?.address as Address
+  )
 
   const formShareAmount = useAtomValue(depositFormShareAmountAtom)
 
   const vaultName = vault.name ?? `"${shareData?.name}"`
   const networkName = getNiceNetworkNameByChainId(vault.chainId)
+
+  const feesToShow: NetworkFeesProps['show'] =
+    tokenPermitSupport === 'eip2612'
+      ? ['depositWithPermit', 'withdraw']
+      : ['approve', 'deposit', 'withdraw']
 
   return (
     <div className='flex flex-col gap-6'>
@@ -58,7 +74,7 @@ export const MainView = (props: MainViewProps) => {
       {!!formShareAmount && (
         <div className='flex flex-col gap-4 mx-auto md:flex-row md:gap-9'>
           <Odds vault={vault} prizePool={prizePool} intl={intl?.base} />
-          <NetworkFees vault={vault} show={['approve', 'deposit', 'withdraw']} intl={intl?.fees} />
+          <NetworkFees vault={vault} show={feesToShow} intl={intl?.fees} />
         </div>
       )}
     </div>

--- a/shared/react-components/components/Modals/DepositModal/Views/ReviewView.tsx
+++ b/shared/react-components/components/Modals/DepositModal/Views/ReviewView.tsx
@@ -1,10 +1,12 @@
 import { PrizePool, Vault } from '@generationsoftware/hyperstructure-client-js'
 import {
+  useTokenPermitSupport,
   useVaultShareData,
   useVaultTokenData
 } from '@generationsoftware/hyperstructure-react-hooks'
 import { Intl, Token, TokenWithLogo } from '@shared/types'
 import { useAtomValue } from 'jotai'
+import { Address } from 'viem'
 import { PrizePoolBadge } from '../../../Badges/PrizePoolBadge'
 import { depositFormShareAmountAtom, depositFormTokenAmountAtom } from '../../../Form/DepositForm'
 import { TokenIcon } from '../../../Icons/TokenIcon'
@@ -30,6 +32,16 @@ export const ReviewView = (props: ReviewViewProps) => {
 
   const { data: shareData } = useVaultShareData(vault)
   const { data: tokenData } = useVaultTokenData(vault)
+
+  const { data: tokenPermitSupport } = useTokenPermitSupport(
+    tokenData?.chainId as number,
+    tokenData?.address as Address
+  )
+
+  const feesToShow: NetworkFeesProps['show'] =
+    tokenPermitSupport === 'eip2612'
+      ? ['depositWithPermit', 'withdraw']
+      : ['approve', 'deposit', 'withdraw']
 
   return (
     <div className='flex flex-col gap-6'>
@@ -58,7 +70,7 @@ export const ReviewView = (props: ReviewViewProps) => {
       )}
       <div className='flex flex-col gap-4 mx-auto md:flex-row md:gap-9'>
         <Odds vault={vault} prizePool={prizePool} intl={intl?.base} />
-        <NetworkFees vault={vault} show={['approve', 'deposit', 'withdraw']} intl={intl?.fees} />
+        <NetworkFees vault={vault} show={feesToShow} intl={intl?.fees} />
       </div>
     </div>
   )

--- a/shared/react-components/components/Modals/NetworkFees.tsx
+++ b/shared/react-components/components/Modals/NetworkFees.tsx
@@ -8,7 +8,7 @@ import { CurrencyValue } from '../Currency/CurrencyValue'
 
 export interface NetworkFeesProps {
   vault: Vault
-  show?: ('approve' | 'deposit' | 'withdraw')[]
+  show?: ('approve' | 'deposit' | 'depositWithPermit' | 'withdraw')[]
   intl?: Intl<'title' | 'approval' | 'deposit' | 'withdrawal'>
 }
 
@@ -25,21 +25,28 @@ export const NetworkFees = (props: NetworkFeesProps) => {
           <TXFeeEstimate
             name={intl?.('approval') ?? 'Approval'}
             chainId={vault?.chainId}
-            gasAmount={BigInt(TX_GAS_ESTIMATES.approve)}
+            gasAmount={TX_GAS_ESTIMATES.approve}
           />
         )}
         {(!show || show.includes('deposit')) && (
           <TXFeeEstimate
             name={intl?.('deposit') ?? 'Deposit'}
             chainId={vault?.chainId}
-            gasAmount={BigInt(TX_GAS_ESTIMATES.deposit)}
+            gasAmount={TX_GAS_ESTIMATES.deposit}
+          />
+        )}
+        {show?.includes('depositWithPermit') && (
+          <TXFeeEstimate
+            name={intl?.('deposit') ?? 'Deposit'}
+            chainId={vault?.chainId}
+            gasAmount={TX_GAS_ESTIMATES.depositWithPermit}
           />
         )}
         {(!show || show.includes('withdraw')) && (
           <TXFeeEstimate
             name={intl?.('withdrawal') ?? 'Withdrawal'}
             chainId={vault?.chainId}
-            gasAmount={BigInt(TX_GAS_ESTIMATES.withdraw)}
+            gasAmount={TX_GAS_ESTIMATES.withdraw}
           />
         )}
       </div>

--- a/shared/react-components/constants.ts
+++ b/shared/react-components/constants.ts
@@ -69,7 +69,8 @@ export const TOKEN_LOGO_OVERRIDES: Record<NETWORK, { [address: Lowercase<string>
  * TX Gas Amount Estimates
  */
 export const TX_GAS_ESTIMATES = Object.freeze({
-  approve: 50_000,
-  deposit: 450_000,
-  withdraw: 300_000
+  approve: 50_000n,
+  deposit: 350_000n,
+  depositWithPermit: 400_000n,
+  withdraw: 300_000n
 })


### PR DESCRIPTION
This PR enables depositing to vaults with underlying tokens that support EIP 2612 through `depositWithPermit` TXs.

The app enables this after checking what the underlying token supports.

If the user already has the underlying token approved (more than the deposit amount), a regular `deposit` transaction is prompted.