### PR TITLE
Added "claim all" button to /account rewards

### DIFF
--- a/apps/app/messages/en.json
+++ b/apps/app/messages/en.json
@@ -128,6 +128,8 @@
     "noPrizesRecently": "You haven't won any prizes recently.",
     "learnHowItWorks": "Learn how PoolTogether works",
     "claimRewardsTx": "{symbol} Rewards Claim",
+    "claimAllRewardsTx": "{network} Multi-Rewards Claim",
+    "claimAllOnNetwork": "Claim all on {network}",
     "winHeaders": {
       "date": "Date",
       "prizePool": "Prize Pool",

--- a/apps/app/src/components/Account/AccountPromotionsHeader.tsx
+++ b/apps/app/src/components/Account/AccountPromotionsHeader.tsx
@@ -1,9 +1,16 @@
-import { CurrencyValue } from '@shared/react-components'
+import { useSendClaimRewardsTransaction } from '@generationsoftware/hyperstructure-react-hooks'
+import { useAddRecentTransaction, useChainModal, useConnectModal } from '@rainbow-me/rainbowkit'
+import { CurrencyValue, TransactionButton } from '@shared/react-components'
 import { Spinner } from '@shared/ui'
+import { getNiceNetworkNameByChainId } from '@shared/utilities'
 import classNames from 'classnames'
 import { useTranslations } from 'next-intl'
+import { useMemo } from 'react'
 import { Address } from 'viem'
 import { useAccount } from 'wagmi'
+import { useNetworks } from '@hooks/useNetworks'
+import { useUserClaimablePromotions } from '@hooks/useUserClaimablePromotions'
+import { useUserClaimedPromotions } from '@hooks/useUserClaimedPromotions'
 import { useUserTotalPromotionRewards } from '@hooks/useUserTotalPromotionRewards'
 
 interface AccountPromotionsHeaderProps {
@@ -19,6 +26,12 @@ export const AccountPromotionsHeader = (props: AccountPromotionsHeaderProps) => 
   const { address: _userAddress } = useAccount()
   const userAddress = address ?? _userAddress
 
+  const networks = useNetworks()
+
+  const isExternalUser = useMemo(() => {
+    return !!address && address.toLowerCase() !== _userAddress?.toLowerCase()
+  }, [address, _userAddress])
+
   const { data: totalRewards } = useUserTotalPromotionRewards(userAddress as Address, {
     includeUnclaimed: true
   })
@@ -33,6 +46,94 @@ export const AccountPromotionsHeader = (props: AccountPromotionsHeaderProps) => 
           <Spinner />
         )}
       </span>
+      {!!userAddress && !isExternalUser && (
+        <div className='flex flex-col gap-2 items-center mt-1'>
+          {networks.map((network) => (
+            <ClaimAllRewardsButton
+              key={`claimAllButton-${network}`}
+              chainId={network}
+              userAddress={userAddress}
+            />
+          ))}
+        </div>
+      )}
     </div>
   )
+}
+
+interface ClaimAllRewardsButtonProps {
+  chainId: number
+  userAddress: Address
+  className?: string
+}
+
+const ClaimAllRewardsButton = (props: ClaimAllRewardsButtonProps) => {
+  const { chainId, userAddress, className } = props
+
+  const t_common = useTranslations('Common')
+  const t_account = useTranslations('Account')
+  const t_txs = useTranslations('TxModals')
+
+  const { openConnectModal } = useConnectModal()
+  const { openChainModal } = useChainModal()
+  const addRecentTransaction = useAddRecentTransaction()
+
+  const { refetch: refetchAllClaimed } = useUserClaimedPromotions(userAddress)
+  const {
+    data: allClaimable,
+    isFetched: isFetchedAllClaimable,
+    refetch: refetchAllClaimable
+  } = useUserClaimablePromotions(userAddress)
+
+  const claimablePromotions = useMemo(() => {
+    return allClaimable.filter((promotion) => promotion.chainId === chainId)
+  }, [allClaimable])
+
+  const epochsToClaim = useMemo(() => {
+    const epochs: { [id: string]: number[] } = {}
+
+    if (isFetchedAllClaimable && claimablePromotions.length > 0) {
+      claimablePromotions.forEach((promotion) => {
+        const epochIds = Object.keys(promotion.epochRewards).map((k) => parseInt(k))
+
+        if (!!epochIds.length) {
+          epochs[promotion.promotionId.toString()] = epochIds
+        }
+      })
+    }
+
+    return epochs
+  }, [claimablePromotions, isFetchedAllClaimable])
+
+  const { isWaiting, isConfirming, isSuccess, txHash, sendClaimRewardsTransaction } =
+    useSendClaimRewardsTransaction(chainId, userAddress, epochsToClaim, {
+      onSuccess: () => {
+        refetchAllClaimed()
+        refetchAllClaimable()
+      }
+    })
+
+  if (Object.keys(epochsToClaim).length > 1) {
+    const network = getNiceNetworkNameByChainId(chainId)
+
+    return (
+      <TransactionButton
+        chainId={chainId}
+        isTxLoading={isWaiting || isConfirming}
+        isTxSuccess={isSuccess}
+        write={sendClaimRewardsTransaction}
+        txHash={txHash}
+        txDescription={t_account('claimAllRewardsTx', { network })}
+        openConnectModal={openConnectModal}
+        openChainModal={openChainModal}
+        addRecentTransaction={addRecentTransaction}
+        intl={{ base: t_txs, common: t_common }}
+        className={classNames('min-w-[6rem]', className)}
+      >
+        {t_account('claimAllOnNetwork', { network })}
+      </TransactionButton>
+    )
+  }
+
+  return <></>
 }


### PR DESCRIPTION
Only displayed when user's wallet is connected, and if there is more than one reward to claim.

This design will probably not look great when we have rewards on multiple networks, so a revision is in order for when that's the case :)