### PR TITLE
WIP: Fix - Chosen language page load flicker

### DIFF
--- a/apps/app/src/components/AppContainer.tsx
+++ b/apps/app/src/components/AppContainer.tsx
@@ -1,10 +1,10 @@
-import { useSelectedLanguage } from '@shared/generic-react-hooks'
+import { useLocalStorageLanguage, useSelectedLanguage } from '@shared/generic-react-hooks'
 import { Flowbite } from '@shared/ui'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { NextIntlProvider } from 'next-intl'
 import { AppProps } from 'next/app'
 import { useRouter } from 'next/router'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
 // React Query Client:
 const queryClient = new QueryClient()
@@ -12,12 +12,22 @@ const queryClient = new QueryClient()
 export const AppContainer = (props: AppProps) => {
   const { Component, pageProps } = props
 
+  const [ready, setReady] = useState<boolean>(false)
+
   const router = useRouter()
 
   useSelectedLanguage({
     onLanguageChange: (locale) => {
       const { pathname, query, asPath } = router
       router.push({ pathname, query }, asPath, { locale })
+    }
+  })
+
+  useLocalStorageLanguage((lang: string | undefined) => {
+    console.log('lang')
+    console.log(lang)
+    if (!ready && lang) {
+      setReady(true)
     }
   })
 
@@ -32,7 +42,7 @@ export const AppContainer = (props: AppProps) => {
       <QueryClientProvider client={queryClient}>
         <NextIntlProvider messages={pageProps.messages}>
           <div id='modal-root' />
-          <Component {...pageProps} />
+          {ready ? <Component {...pageProps} /> : null}
         </NextIntlProvider>
       </QueryClientProvider>
     </Flowbite>

--- a/shared/generic-react-hooks/app/useSelectedLanguage.ts
+++ b/shared/generic-react-hooks/app/useSelectedLanguage.ts
@@ -14,6 +14,32 @@ const getInitialSelectedLanguage = (): LANGUAGE_ID => {
   }
 }
 
+export const useLocalStorageLanguage = (
+  callback: (lang: LANGUAGE_ID | undefined) => void
+): void => {
+  let lang
+  if (typeof window === 'undefined') {
+    console.log('4')
+    lang = 'en' as LANGUAGE_ID
+  }
+
+  if (typeof Storage !== 'undefined') {
+    const cachedLanguage = localStorage.getItem(LOCAL_STORAGE_KEYS.selectedLanguage)
+    if (!!cachedLanguage && cachedLanguage in SUPPORTED_LANGUAGES) {
+      console.log('1')
+      lang = cachedLanguage as LANGUAGE_ID
+    } else {
+      console.log('2')
+      lang = 'en' as LANGUAGE_ID
+    }
+  } else {
+    console.log('3')
+    lang = 'en' as LANGUAGE_ID
+  }
+
+  callback(lang)
+}
+
 const selectedLanguageAtom = atom<LANGUAGE_ID>(getInitialSelectedLanguage())
 
 /**


### PR DESCRIPTION
Attempting to prevent the flicker of English to whatever the previously chosen language is for a user.

Currently this looks as though it should work, as in the browser it only ever logs: `1, lang, es` for me (since I have 'es' in my localStorage). However, I believe due to the next.js server/client hydration it still loads english on the server so we see english when the page loads.

**Next steps:** Will look further into how to tame this with next.js.