### PR TITLE
Custom RPCs

### DIFF
--- a/apps/app/messages/en.json
+++ b/apps/app/messages/en.json
@@ -238,6 +238,7 @@
     "changeLanguage": "Change Language",
     "viewEcosystem": "View Ecosystem",
     "manageVaultLists": "Manage Vault Lists",
+    "setCustomRPCs": "Set Custom RPCs",
     "getHelp": "Get Help",
     "getHelpWithCabana": "Get Help w/ Using Cabana",
     "vaultListsDescription": "Vault lists determine what prize vaults are displayed throughout the app. Use caution when interacting with imported lists.",
@@ -246,7 +247,13 @@
     "addVaultList": "Add Vault List",
     "clearImportedVaultLists": "Clear all imported vault lists",
     "numTokens": "{number, plural, one {# Token} other {# Tokens}}",
-    "imported": "Imported"
+    "imported": "Imported",
+    "customRpcDescription": "Route the app's onchain queries through RPCs of your choosing. These are stored locally on your browser.",
+    "customNetworkRpc": "Custom {network} RPC",
+    "override": "override",
+    "default": "Default",
+    "set": "Set",
+    "refreshToUpdateRPCs": "Refresh the page to see changes"
   },
   "Abbreviations": {
     "days": "days",
@@ -326,7 +333,9 @@
       "invalidAddress": "Enter a valid EVM address",
       "sameAsDelegate": "Entered address is same as current delegate",
       "negativeNumber": "Enter a positive number",
-      "tooManyDecimals": "Too many decimals"
+      "tooManyDecimals": "Too many decimals",
+      "invalidRpcNetwork": "This RPC doesn't seem to be for the {network} network",
+      "invalidRpcUrl": "Not a valid RPC URL"
     }
   }
 }

--- a/apps/app/src/components/Layout.tsx
+++ b/apps/app/src/components/Layout.tsx
@@ -34,6 +34,7 @@ import { ReactNode, useEffect, useState } from 'react'
 import { Address } from 'viem'
 import { useAccount } from 'wagmi'
 import { DEFAULT_VAULT_LISTS, FATHOM_EVENTS } from '@constants/config'
+import { useNetworks } from '@hooks/useNetworks'
 import { useSelectedPrizePool } from '@hooks/useSelectedPrizePool'
 import { useSettingsModalView } from '@hooks/useSettingsModalView'
 import { useSupportedPrizePools } from '@hooks/useSupportedPrizePools'
@@ -67,6 +68,7 @@ export const Layout = (props: LayoutProps) => {
 
   const { setIsModalOpen: setIsCaptchaModalOpen } = useIsModalOpen(MODAL_KEYS.captcha)
 
+  const supportedNetworks = useNetworks()
   const { isTestnets, setIsTestnets } = useIsTestnets()
 
   const { openConnectModal } = useConnectModal()
@@ -226,6 +228,7 @@ export const Layout = (props: LayoutProps) => {
         setView={setSettingsModalView}
         locales={['en', 'de', 'ru', 'ko', 'uk', 'hi', 'es']}
         localVaultLists={DEFAULT_VAULT_LISTS}
+        supportedNetworks={supportedNetworks}
         onCurrencyChange={() => fathom.trackEvent(FATHOM_EVENTS.changedCurrency)}
         onLanguageChange={() => fathom.trackEvent(FATHOM_EVENTS.changedLanguage)}
         onVaultListImport={() => fathom.trackEvent(FATHOM_EVENTS.importedVaultList)}

--- a/apps/app/src/components/Layout.tsx
+++ b/apps/app/src/components/Layout.tsx
@@ -226,6 +226,7 @@ export const Layout = (props: LayoutProps) => {
       <SettingsModal
         view={settingsModalView}
         setView={setSettingsModalView}
+        reloadPage={() => router.reload()}
         locales={['en', 'de', 'ru', 'ko', 'uk', 'hi', 'es']}
         localVaultLists={DEFAULT_VAULT_LISTS}
         supportedNetworks={supportedNetworks}

--- a/apps/app/src/components/Layout.tsx
+++ b/apps/app/src/components/Layout.tsx
@@ -22,7 +22,7 @@ import {
   WithdrawModal
 } from '@shared/react-components'
 import { Footer, FooterItem, LINKS, Navbar, SocialIcon, toast } from '@shared/ui'
-import { getDiscordInvite } from '@shared/utilities'
+import { getDiscordInvite, NETWORK } from '@shared/utilities'
 import classNames from 'classnames'
 import * as fathom from 'fathom-client'
 import { useAtomValue } from 'jotai'
@@ -30,7 +30,7 @@ import { useTranslations } from 'next-intl'
 import Head from 'next/head'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { ReactNode, useEffect, useState } from 'react'
+import { ReactNode, useEffect, useMemo, useState } from 'react'
 import { Address } from 'viem'
 import { useAccount } from 'wagmi'
 import { DEFAULT_VAULT_LISTS, FATHOM_EVENTS } from '@constants/config'
@@ -70,6 +70,10 @@ export const Layout = (props: LayoutProps) => {
 
   const supportedNetworks = useNetworks()
   const { isTestnets, setIsTestnets } = useIsTestnets()
+
+  const customRpcNetworks = useMemo(() => {
+    return [...new Set([NETWORK.mainnet, ...supportedNetworks])]
+  }, [supportedNetworks])
 
   const { openConnectModal } = useConnectModal()
   const { openChainModal } = useChainModal()
@@ -229,7 +233,7 @@ export const Layout = (props: LayoutProps) => {
         reloadPage={() => router.reload()}
         locales={['en', 'de', 'ru', 'ko', 'uk', 'hi', 'es']}
         localVaultLists={DEFAULT_VAULT_LISTS}
-        supportedNetworks={supportedNetworks}
+        supportedNetworks={customRpcNetworks}
         onCurrencyChange={() => fathom.trackEvent(FATHOM_EVENTS.changedCurrency)}
         onLanguageChange={() => fathom.trackEvent(FATHOM_EVENTS.changedLanguage)}
         onVaultListImport={() => fathom.trackEvent(FATHOM_EVENTS.importedVaultList)}

--- a/apps/app/src/pages/_app.tsx
+++ b/apps/app/src/pages/_app.tsx
@@ -10,7 +10,7 @@ import '../styles/globals.css'
 import { createCustomWagmiConfig } from '../utils'
 
 const networks = [...SUPPORTED_NETWORKS.mainnets, ...SUPPORTED_NETWORKS.testnets]
-const wagmiConfig = createCustomWagmiConfig(networks)
+const wagmiConfig = createCustomWagmiConfig(networks, { useCustomRPCs: true })
 
 export default function MyApp(props: AppProps) {
   useFathom()

--- a/shared/generic-react-hooks/README.md
+++ b/shared/generic-react-hooks/README.md
@@ -21,6 +21,7 @@ A library of shared React hooks with minimal dependencies.
 
 - `useCountdown`
 - `useCountup`
+- `useCustomRPCs`
 - `useIsDismissed`
 - `useIsModalOpen`
 - `useIsTestnets`

--- a/shared/generic-react-hooks/app/useCustomRPCs.ts
+++ b/shared/generic-react-hooks/app/useCustomRPCs.ts
@@ -1,0 +1,44 @@
+import { atom, useAtom } from 'jotai'
+import { useEffect } from 'react'
+import { LOCAL_STORAGE_KEYS } from '../constants/keys'
+
+const getInitialCustomRPCs = (): { [chainId: number]: string | undefined } => {
+  if (typeof window === 'undefined') return {}
+  const cachedCustomRPCs = localStorage.getItem(LOCAL_STORAGE_KEYS.customRPCs)
+  return JSON.parse(cachedCustomRPCs ?? '{}')
+}
+
+const cachedCustomRPCsAtom = atom<{ [chainId: string]: string | undefined }>(getInitialCustomRPCs())
+
+/**
+ * Returns custom RPC URLs and methods to change them
+ *
+ * Stores state in local storage
+ * @returns
+ */
+export const useCustomRPCs = () => {
+  const [customRPCs, setCustomRPCs] = useAtom(cachedCustomRPCsAtom)
+
+  const set = (chainId: number, customRPC: string) => {
+    setCustomRPCs((prev) => ({ ...prev, [chainId]: customRPC }))
+  }
+
+  const setAll = (customRPCs: { [chainId: number]: string }) => {
+    setCustomRPCs(customRPCs)
+  }
+
+  const remove = (chainId: number) => {
+    setCustomRPCs((prev) => ({ ...prev, [chainId]: undefined }))
+  }
+
+  const clear = () => {
+    setCustomRPCs({})
+  }
+
+  useEffect(
+    () => localStorage.setItem(LOCAL_STORAGE_KEYS.customRPCs, JSON.stringify(customRPCs)),
+    [customRPCs]
+  )
+
+  return { customRPCs, set, setAll, remove, clear }
+}

--- a/shared/generic-react-hooks/app/useCustomRPCs.ts
+++ b/shared/generic-react-hooks/app/useCustomRPCs.ts
@@ -2,7 +2,7 @@ import { atom, useAtom } from 'jotai'
 import { useEffect } from 'react'
 import { LOCAL_STORAGE_KEYS } from '../constants/keys'
 
-const getInitialCustomRPCs = (): { [chainId: number]: string | undefined } => {
+export const getInitialCustomRPCs = (): { [chainId: number]: string | undefined } => {
   if (typeof window === 'undefined') return {}
   const cachedCustomRPCs = localStorage.getItem(LOCAL_STORAGE_KEYS.customRPCs)
   return JSON.parse(cachedCustomRPCs ?? '{}')

--- a/shared/generic-react-hooks/constants/keys.ts
+++ b/shared/generic-react-hooks/constants/keys.ts
@@ -15,7 +15,8 @@ export const LOCAL_STORAGE_KEYS = Object.freeze({
   isTestnets: 'isTestnets',
   isDismissed: 'isDismissed',
   selectedCurrency: 'selectedCurrency',
-  selectedLanguage: 'selectedLanguage'
+  selectedLanguage: 'selectedLanguage',
+  customRPCs: 'customRPCs'
 })
 
 /**

--- a/shared/generic-react-hooks/index.ts
+++ b/shared/generic-react-hooks/index.ts
@@ -3,6 +3,7 @@
  */
 export * from './app/useCountdown'
 export * from './app/useCountup'
+export * from './app/useCustomRPCs'
 export * from './app/useIsDismissed'
 export * from './app/useIsModalOpen'
 export * from './app/useIsTestnets'

--- a/shared/react-components/components/Form/DelegateForm.tsx
+++ b/shared/react-components/components/Form/DelegateForm.tsx
@@ -3,15 +3,15 @@ import { useUserVaultDelegate } from '@generationsoftware/hyperstructure-react-h
 import { PencilIcon } from '@heroicons/react/24/outline'
 import { Intl } from '@shared/types'
 import { Spinner } from '@shared/ui'
+import classNames from 'classnames'
 import { atom, useSetAtom } from 'jotai'
-import { useEffect } from 'react'
+import { ReactNode, useEffect } from 'react'
 import { useState } from 'react'
-import { FormProvider, useForm } from 'react-hook-form'
+import { FormProvider, useForm, useFormContext, useWatch } from 'react-hook-form'
 import { Address, isAddress } from 'viem'
 import { useAccount } from 'wagmi'
 import { DelegateModalView } from '../Modals/DelegateModal'
 import { DelegationDescriptionTooltip } from '../Tooltips/DelegationDescriptionTooltip'
-import { SimpleInput } from './SimpleInput'
 
 export const delegateFormNewDelegateAddressAtom = atom<Address | undefined>('0x')
 
@@ -67,7 +67,7 @@ export const DelegateForm = (props: DelegateFormProps) => {
   return (
     <div className='flex flex-col'>
       <FormProvider {...formMethods}>
-        <SimpleInput
+        <DelegateInput
           formKey='newDelegateAddress'
           autoComplete='off'
           disabled={disabled}
@@ -107,6 +107,115 @@ export const DelegateForm = (props: DelegateFormProps) => {
           className='w-full max-w-md'
         />
       </FormProvider>
+    </div>
+  )
+}
+
+interface DelegateInputProps {
+  formKey: string
+  id?: string
+  autoComplete?: string
+  validate?: { [rule: string]: (v: any) => true | string }
+  placeholder?: string
+  defaultValue?: string
+  label?: ReactNode
+  hideErrorMsgs?: boolean
+  autoFocus?: boolean
+  disabled?: boolean
+  needsOverride?: boolean
+  isActiveOverride?: boolean
+  setIsActiveOverride?: (val: boolean) => void
+  overrideLabel?: ReactNode
+  keepValueOnOverride?: boolean
+  onOverride?: (val: boolean) => void
+  className?: string
+  labelClassName?: string
+  innerClassName?: string
+  errorClassName?: string
+}
+
+export const DelegateInput = (props: DelegateInputProps) => {
+  const {
+    formKey,
+    id,
+    autoComplete,
+    validate,
+    placeholder,
+    defaultValue,
+    label,
+    hideErrorMsgs,
+    autoFocus,
+    disabled,
+    needsOverride,
+    setIsActiveOverride,
+    isActiveOverride,
+    overrideLabel,
+    keepValueOnOverride,
+    onOverride,
+    className,
+    labelClassName,
+    innerClassName,
+    errorClassName
+  } = props
+
+  const { register, formState, setValue } = useFormContext()
+
+  const formValues = useWatch()
+
+  const handleOverride = () => {
+    !keepValueOnOverride && setValue(formKey, '')
+    setIsActiveOverride?.(true)
+    onOverride?.(true)
+  }
+
+  const handleBlur = () => {
+    if ((needsOverride && !formValues[formKey]) || formValues[formKey] === defaultValue) {
+      setValue(formKey, defaultValue, { shouldValidate: true })
+      setIsActiveOverride?.(false)
+      onOverride?.(false)
+    }
+  }
+
+  const error = formState.errors[formKey]?.message as string | undefined
+
+  return (
+    <div className={classNames('flex flex-col gap-2', className)}>
+      <label
+        htmlFor={id ?? formKey}
+        className={classNames('flex items-center justify-between text-sm', labelClassName)}
+      >
+        <span className='font-medium text-pt-purple-100'>{label}</span>
+        {needsOverride && !isActiveOverride && (
+          <span onClick={handleOverride} className='text-pt-teal cursor-pointer underline'>
+            {overrideLabel ?? 'override'}
+          </span>
+        )}
+      </label>
+      <input
+        id={id ?? formKey}
+        {...register(formKey, { validate })}
+        placeholder={placeholder}
+        defaultValue={defaultValue}
+        autoFocus={autoFocus}
+        onBlur={handleBlur}
+        autoComplete={autoComplete}
+        onClick={handleOverride}
+        className={classNames(
+          'px-3 py-2 text-sm leading-tight rounded-lg border outline outline-1',
+          'md:px-4 md:py-3',
+          {
+            'bg-pt-purple-50 text-gray-700 border-gray-300':
+              !needsOverride || (needsOverride && isActiveOverride),
+            'bg-transparent text-pt-teal border-pt-teal cursor-pointer':
+              needsOverride && !isActiveOverride,
+            'brightness-75': disabled,
+            [`outline-red-600 ${errorClassName}`]: !!error,
+            'outline-transparent': !error
+          },
+          innerClassName
+        )}
+      />
+      {!hideErrorMsgs && <span className='text-xs text-pt-warning-light'>{error}</span>}
     </div>
   )
 }

--- a/shared/react-components/components/Form/SimpleInput.tsx
+++ b/shared/react-components/components/Form/SimpleInput.tsx
@@ -1,21 +1,19 @@
 import classNames from 'classnames'
-import { ReactNode } from 'react'
+import { ReactNode, useState } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
 
 interface SimpleInputProps {
   formKey: string
   id?: string
-  autoComplete?: string
   validate?: { [rule: string]: (v: any) => true | string }
   placeholder?: string
   defaultValue?: string
   label?: ReactNode
   hideErrorMsgs?: boolean
   autoFocus?: boolean
+  autoComplete?: string
   disabled?: boolean
   needsOverride?: boolean
-  isActiveOverride?: boolean
-  setIsActiveOverride?: (val: boolean) => void
   overrideLabel?: ReactNode
   keepValueOnOverride?: boolean
   onOverride?: (val: boolean) => void
@@ -29,17 +27,15 @@ export const SimpleInput = (props: SimpleInputProps) => {
   const {
     formKey,
     id,
-    autoComplete,
     validate,
     placeholder,
     defaultValue,
     label,
     hideErrorMsgs,
     autoFocus,
+    autoComplete,
     disabled,
     needsOverride,
-    setIsActiveOverride,
-    isActiveOverride,
     overrideLabel,
     keepValueOnOverride,
     onOverride,
@@ -53,16 +49,18 @@ export const SimpleInput = (props: SimpleInputProps) => {
 
   const formValues = useWatch()
 
+  const [isActiveOverride, setIsActiveOverride] = useState<boolean>(false)
+
   const handleOverride = () => {
     !keepValueOnOverride && setValue(formKey, '')
-    setIsActiveOverride?.(true)
+    setIsActiveOverride(true)
     onOverride?.(true)
   }
 
   const handleBlur = () => {
     if ((needsOverride && !formValues[formKey]) || formValues[formKey] === defaultValue) {
       setValue(formKey, defaultValue, { shouldValidate: true })
-      setIsActiveOverride?.(false)
+      setIsActiveOverride(false)
       onOverride?.(false)
     }
   }
@@ -88,17 +86,16 @@ export const SimpleInput = (props: SimpleInputProps) => {
         placeholder={placeholder}
         defaultValue={defaultValue}
         autoFocus={autoFocus}
-        onBlur={handleBlur}
         autoComplete={autoComplete}
-        onClick={handleOverride}
+        disabled={disabled || (needsOverride && !isActiveOverride)}
+        onBlur={handleBlur}
         className={classNames(
           'px-3 py-2 text-sm leading-tight rounded-lg border outline outline-1',
           'md:px-4 md:py-3',
           {
             'bg-pt-purple-50 text-gray-700 border-gray-300':
               !needsOverride || (needsOverride && isActiveOverride),
-            'bg-transparent text-pt-teal border-pt-teal cursor-pointer':
-              needsOverride && !isActiveOverride,
+            'bg-transparent text-pt-teal border-pt-teal': needsOverride && !isActiveOverride,
             'brightness-75': disabled,
             [`outline-red-600 ${errorClassName}`]: !!error,
             'outline-transparent': !error

--- a/shared/react-components/components/Modals/SettingsModal/Views/MenuView.tsx
+++ b/shared/react-components/components/Modals/SettingsModal/Views/MenuView.tsx
@@ -21,6 +21,7 @@ interface MenuViewProps {
     | 'changeLanguage'
     | 'viewEcosystem'
     | 'manageVaultLists'
+    | 'setCustomRPCs'
     | 'getHelp'
     | 'getHelpWithCabana'
   >
@@ -66,7 +67,7 @@ export const MenuView = (props: MenuViewProps) => {
           },
           {
             iconContent: <CubeTransparentIcon className='h-6 w-6 text-pt-purple-100' />,
-            title: 'Set Custom RPCs', // TODO: intl
+            title: intl?.('setCustomRPCs') ?? 'Set Custom RPCs',
             onClick: () => setView('customRPCs'),
             disabled: disable?.includes('customRPCs'),
             hidden: hide?.includes('customRPCs')

--- a/shared/react-components/components/Modals/SettingsModal/Views/MenuView.tsx
+++ b/shared/react-components/components/Modals/SettingsModal/Views/MenuView.tsx
@@ -63,6 +63,13 @@ export const MenuView = (props: MenuViewProps) => {
             onClick: () => setView('vaultLists'),
             disabled: disable?.includes('vaultLists'),
             hidden: hide?.includes('vaultLists')
+          },
+          {
+            iconContent: '?', // TODO: set rpcs icon
+            title: 'Set Custom RPCs', // TODO: intl
+            onClick: () => setView('customRPCs'),
+            disabled: disable?.includes('customRPCs'),
+            hidden: hide?.includes('customRPCs')
           }
         ]}
       />

--- a/shared/react-components/components/Modals/SettingsModal/Views/MenuView.tsx
+++ b/shared/react-components/components/Modals/SettingsModal/Views/MenuView.tsx
@@ -1,4 +1,4 @@
-import { SparklesIcon } from '@heroicons/react/24/outline'
+import { CubeTransparentIcon, SparklesIcon } from '@heroicons/react/24/outline'
 import {
   SUPPORTED_CURRENCIES,
   useSelectedCurrency,
@@ -65,7 +65,7 @@ export const MenuView = (props: MenuViewProps) => {
             hidden: hide?.includes('vaultLists')
           },
           {
-            iconContent: '?', // TODO: set rpcs icon
+            iconContent: <CubeTransparentIcon className='h-6 w-6 text-pt-purple-100' />,
             title: 'Set Custom RPCs', // TODO: intl
             onClick: () => setView('customRPCs'),
             disabled: disable?.includes('customRPCs'),

--- a/shared/react-components/components/Modals/SettingsModal/Views/RPCsView.tsx
+++ b/shared/react-components/components/Modals/SettingsModal/Views/RPCsView.tsx
@@ -40,7 +40,8 @@ export const RPCsView = (props: RPCsViewProps) => {
           onClick={onClickPageReload}
           className='inline-flex gap-2 items-center justify-center text-center text-sm text-pt-purple-200 cursor-pointer'
         >
-          <ArrowPathRoundedSquareIcon className='h-6 w-6' /> Refresh the page to see changes
+          <ArrowPathRoundedSquareIcon className='h-6 w-6' />
+          <span>Refresh the page to see changes</span>
         </span>
       )}
     </div>
@@ -57,7 +58,8 @@ const Header = (props: HeaderProps) => {
     <div className='flex flex-col items-center gap-2 text-center'>
       <span className='text-lg font-semibold md:text-xl'>Set Custom RPCs</span>
       <span className='text-sm text-pt-purple-50 md:text-base'>
-        Want to route the app's onchain queries to an RPC of your choice? Feel free to do so here!
+        Route the app's onchain queries through RPCs of your choosing. These are stored locally on
+        your browser.
       </span>
     </div>
   )
@@ -144,7 +146,7 @@ const CustomRPCInput = (props: CustomRPCInputProps) => {
         />
         <div
           className={classNames('flex gap-2 items-center sm:mt-5', {
-            'sm:mt-1': !formMethods.formState.isValid
+            'sm:!mt-1': !formMethods.formState.isValid
           })}
         >
           <SetCustomRpcButton

--- a/shared/react-components/components/Modals/SettingsModal/Views/RPCsView.tsx
+++ b/shared/react-components/components/Modals/SettingsModal/Views/RPCsView.tsx
@@ -43,7 +43,7 @@ const Header = (props: HeaderProps) => {
     <div className='flex flex-col items-center gap-2 text-center'>
       <span className='text-lg font-semibold md:text-xl'>Set Custom RPCs</span>
       <span className='text-sm text-pt-purple-50 md:text-base'>
-        Cabana's default RPCs will be used if custom RPCs aren't provided for any network.
+        Want to route the app's onchain queries to an RPC of your choice? Feel free to do so here!
       </span>
     </div>
   )
@@ -125,31 +125,12 @@ const CustomRPCInput = (props: CustomRPCInputProps) => {
           className='w-full'
           innerClassName={classNames({ 'brightness-75': isCheckingRPC })}
         />
-        <Button
-          type='submit'
-          color='purple'
-          className='relative bg-pt-purple-600 border-pt-purple-600 hover:bg-pt-purple-500 focus:outline-transparent'
-          disabled={
-            isCheckingRPC ||
-            !formMethods.formState.isValid ||
-            formMethods.formState.isValidating ||
-            checkedRpcUrl === formRpcUrl?.trim()
-          }
-        >
-          <span
-            className={classNames('py-[1px] text-pt-purple-50 whitespace-nowrap', {
-              'opacity-0': !!formRpcUrl && (isCheckingRPC || checkedRpcUrl === formRpcUrl.trim())
-            })}
-          >
-            Check
-          </span>
-          {/* TODO: use check and X images */}
-          {!!formRpcUrl &&
-            !isCheckingRPC &&
-            checkedRpcUrl === formRpcUrl.trim() &&
-            (formMethods.formState.isValid ? <>YES</> : <>NO</>)}
-          {isCheckingRPC && <Spinner className='absolute left-0 right-0 mx-auto' />}
-        </Button>
+        <SetCustomRpcButton
+          formRpcUrl={formRpcUrl}
+          checkedRpcUrl={checkedRpcUrl}
+          isCheckingRPC={isCheckingRPC}
+          isFormValid={formMethods.formState.isValid && !formMethods.formState.isValidating}
+        />
         <TrashIcon
           onClick={() => {
             remove(chainId)
@@ -162,3 +143,83 @@ const CustomRPCInput = (props: CustomRPCInputProps) => {
     </FormProvider>
   )
 }
+
+interface SetCustomRpcButtonProps {
+  formRpcUrl: string | undefined
+  checkedRpcUrl: string
+  isCheckingRPC: boolean
+  isFormValid: boolean
+  className?: string
+}
+
+const SetCustomRpcButton = (props: SetCustomRpcButtonProps) => {
+  const { formRpcUrl, checkedRpcUrl, isCheckingRPC, isFormValid, className } = props
+
+  const isFormRpcUrlChecked = !isCheckingRPC && checkedRpcUrl === formRpcUrl?.trim()
+  const isDefaultRpcUrl = !formRpcUrl && !checkedRpcUrl
+
+  const isButtonDisabled = isCheckingRPC || isFormRpcUrlChecked || !isFormValid || isDefaultRpcUrl
+  const isButtonTextHidden = !!formRpcUrl && (isCheckingRPC || isFormRpcUrlChecked)
+
+  const isSubmitted = !!formRpcUrl && isFormRpcUrlChecked
+
+  const iconClassName = 'absolute inset-x-0 text-pt-purple-50 opacity-0'
+
+  return (
+    <Button
+      type='submit'
+      color='purple'
+      className={classNames(
+        'relative bg-pt-purple-600 border-pt-purple-600 hover:bg-pt-purple-500 focus:outline-transparent',
+        className
+      )}
+      disabled={isButtonDisabled}
+    >
+      <div className='py-[1px] text-pt-purple-50'>
+        <span className={classNames({ 'opacity-0': isButtonTextHidden || !isDefaultRpcUrl })}>
+          Default
+        </span>
+        {!isButtonTextHidden && !isDefaultRpcUrl && <span className='absolute inset-x-0'>Set</span>}
+      </div>
+      <CheckIcon
+        className={classNames(iconClassName, { 'opacity-100': isSubmitted && isFormValid })}
+      />
+      <XIcon
+        className={classNames(iconClassName, { 'opacity-100': isSubmitted && !isFormValid })}
+      />
+      {isCheckingRPC && <Spinner className='absolute left-0 right-0 mx-auto' />}
+    </Button>
+  )
+}
+
+const CheckIcon = (props: { className?: string }) => (
+  <svg
+    fill='none'
+    stroke='currentColor'
+    strokeWidth={1.5}
+    viewBox='0 0 24 24'
+    xmlns='http://www.w3.org/2000/svg'
+    aria-hidden='true'
+    className={props.className}
+  >
+    <path strokeLinecap='round' strokeLinejoin='round' d='M 9 12.75 L 11.25 15 15 9.75' />
+  </svg>
+)
+
+const XIcon = (props: { className?: string }) => (
+  <svg
+    fill='none'
+    stroke='currentColor'
+    strokeWidth={1.5}
+    viewBox='0 0 24 24'
+    xmlns='http://www.w3.org/2000/svg'
+    aria-hidden='true'
+    className={props.className}
+  >
+    <path
+      strokeLinecap='round'
+      strokeLinejoin='round'
+      d='M 9.75 9.75 l 4.5 4.5 m 0 -4.5 l -4.5 4.5'
+    />
+  </svg>
+)

--- a/shared/react-components/components/Modals/SettingsModal/Views/RPCsView.tsx
+++ b/shared/react-components/components/Modals/SettingsModal/Views/RPCsView.tsx
@@ -109,7 +109,7 @@ const CustomRPCInput = (props: CustomRPCInputProps) => {
     <FormProvider {...formMethods}>
       <form
         onSubmit={formMethods.handleSubmit(onSubmit)}
-        className={classNames('inline-flex flex-col gap-x-4 gap-y-2 sm:flex-row', className)}
+        className={classNames('inline-flex flex-col gap-2 sm:flex-row', className)}
       >
         {/* TODO: use intl for `overrideLabel` */}
         <SimpleInput
@@ -125,25 +125,33 @@ const CustomRPCInput = (props: CustomRPCInputProps) => {
           className='w-full'
           innerClassName={classNames({ 'brightness-75': isCheckingRPC })}
         />
-        <SetCustomRpcButton
-          formRpcUrl={formRpcUrl}
-          checkedRpcUrl={checkedRpcUrl}
-          isCheckingRPC={isCheckingRPC}
-          isFormValid={formMethods.formState.isValid && !formMethods.formState.isValidating}
-        />
-        <TrashIcon
-          onClick={() => {
-            remove(chainId)
-            formMethods.setValue('rpc', '')
-            setCheckedRpcUrl('')
-          }}
-          className='h-5 w-5 text-pt-purple-200 cursor-pointer'
-        />
+        <div
+          className={classNames('flex gap-2 items-center sm:mt-5', {
+            'sm:mt-1': !formMethods.formState.isValid
+          })}
+        >
+          <SetCustomRpcButton
+            formRpcUrl={formRpcUrl}
+            checkedRpcUrl={checkedRpcUrl}
+            isCheckingRPC={isCheckingRPC}
+            isFormValid={formMethods.formState.isValid && !formMethods.formState.isValidating}
+            className='flex-grow'
+          />
+          <TrashIcon
+            onClick={() => {
+              remove(chainId)
+              formMethods.setValue('rpc', '')
+              setCheckedRpcUrl('')
+            }}
+            className='h-6 w-auto text-pt-purple-200 cursor-pointer'
+          />
+        </div>
       </form>
     </FormProvider>
   )
 }
 
+// TODO: intl
 interface SetCustomRpcButtonProps {
   formRpcUrl: string | undefined
   checkedRpcUrl: string
@@ -163,7 +171,7 @@ const SetCustomRpcButton = (props: SetCustomRpcButtonProps) => {
 
   const isSubmitted = !!formRpcUrl && isFormRpcUrlChecked
 
-  const iconClassName = 'absolute inset-x-0 text-pt-purple-50 opacity-0'
+  const iconClassName = 'absolute inset-x-0 max-h-12 mx-auto text-pt-purple-50 opacity-0'
 
   return (
     <Button

--- a/shared/react-components/components/Modals/SettingsModal/Views/RPCsView.tsx
+++ b/shared/react-components/components/Modals/SettingsModal/Views/RPCsView.tsx
@@ -1,0 +1,164 @@
+import { TrashIcon } from '@heroicons/react/24/outline'
+import { useCustomRPCs } from '@shared/generic-react-hooks'
+import { Intl } from '@shared/types'
+import { Button, Spinner } from '@shared/ui'
+import { getNiceNetworkNameByChainId, NETWORK } from '@shared/utilities'
+import classNames from 'classnames'
+import { useState } from 'react'
+import { FormProvider, useForm } from 'react-hook-form'
+import { createPublicClient, http } from 'viem'
+import { SimpleInput } from '../../../Form/SimpleInput'
+
+// TODO: intl
+interface RPCsViewProps {
+  chainIds: NETWORK[]
+}
+
+// TODO: empty state for when chainIds is an empty array
+export const RPCsView = (props: RPCsViewProps) => {
+  const { chainIds } = props
+
+  return (
+    <div className='flex flex-col gap-4 md:gap-8'>
+      <Header />
+
+      <div className='flex flex-col gap-2'>
+        {chainIds.map((chainId) => (
+          <CustomRPCInput key={`customRPC-${chainId}`} chainId={chainId} />
+        ))}
+      </div>
+
+      {/* TODO: add button to prompt for app refesh (if necessary) */}
+    </div>
+  )
+}
+
+// TODO: intl
+interface HeaderProps {}
+
+const Header = (props: HeaderProps) => {
+  const {} = props
+
+  return (
+    <div className='flex flex-col items-center gap-2 text-center'>
+      <span className='text-lg font-semibold md:text-xl'>Set Custom RPCs</span>
+      <span className='text-sm text-pt-purple-50 md:text-base'>
+        Cabana's default RPCs will be used if custom RPCs aren't provided for any network.
+      </span>
+    </div>
+  )
+}
+
+// TODO: intl
+interface CustomRPCInputProps {
+  chainId: NETWORK
+  className?: string
+}
+
+const CustomRPCInput = (props: CustomRPCInputProps) => {
+  const { chainId, className } = props
+
+  const { customRPCs, set, remove } = useCustomRPCs()
+
+  const formMethods = useForm<{ rpc: string }>({
+    mode: 'onChange',
+    defaultValues: { rpc: customRPCs[chainId] ?? '' }
+  })
+
+  const { rpc: formRpcUrl } = formMethods.watch()
+
+  const [checkedRpcUrl, setCheckedRpcUrl] = useState<string>(customRPCs[chainId] ?? '')
+  const [isCheckingRPC, setIsCheckingRPC] = useState<boolean>(false)
+
+  const networkName = getNiceNetworkNameByChainId(chainId)
+
+  const onSubmit = async (data: { rpc: string }) => {
+    setIsCheckingRPC(true)
+    formMethods.clearErrors('rpc')
+
+    const cleanRpcUrl = data.rpc?.trim()
+
+    try {
+      if (!!cleanRpcUrl) {
+        const publicClient = createPublicClient({ transport: http(cleanRpcUrl) })
+        const rpcChainId = await publicClient.getChainId()
+
+        if (rpcChainId === chainId) {
+          set(chainId, cleanRpcUrl)
+          formMethods.clearErrors('rpc')
+        } else {
+          formMethods.setError('rpc', {
+            message: `This RPC doesn't seem to be for the ${networkName} network`
+          })
+        }
+      } else {
+        remove(chainId)
+        formMethods.clearErrors('rpc')
+      }
+    } catch (err) {
+      formMethods.setError('rpc', {
+        message: 'Not a valid RPC URL'
+      })
+    } finally {
+      setCheckedRpcUrl(cleanRpcUrl ?? '')
+      setIsCheckingRPC(false)
+    }
+  }
+
+  return (
+    <FormProvider {...formMethods}>
+      <form
+        onSubmit={formMethods.handleSubmit(onSubmit)}
+        className={classNames('inline-flex flex-col gap-x-4 gap-y-2 sm:flex-row', className)}
+      >
+        {/* TODO: use intl for `overrideLabel` */}
+        <SimpleInput
+          formKey='rpc'
+          needsOverride={true}
+          keepValueOnOverride={true}
+          label={`Custom ${networkName} RPC`}
+          validate={{
+            isValidURL: (v) =>
+              !v || v.startsWith('http://') || v.startsWith('https://') || 'Not a valid RPC URL'
+          }}
+          placeholder='https://...'
+          className='w-full'
+          innerClassName={classNames({ 'brightness-75': isCheckingRPC })}
+        />
+        <Button
+          type='submit'
+          color='purple'
+          className='relative bg-pt-purple-600 border-pt-purple-600 hover:bg-pt-purple-500 focus:outline-transparent'
+          disabled={
+            isCheckingRPC ||
+            !formMethods.formState.isValid ||
+            formMethods.formState.isValidating ||
+            checkedRpcUrl === formRpcUrl?.trim()
+          }
+        >
+          <span
+            className={classNames('py-[1px] text-pt-purple-50 whitespace-nowrap', {
+              'opacity-0': !!formRpcUrl && (isCheckingRPC || checkedRpcUrl === formRpcUrl.trim())
+            })}
+          >
+            Check
+          </span>
+          {/* TODO: use check and X images */}
+          {!!formRpcUrl &&
+            !isCheckingRPC &&
+            checkedRpcUrl === formRpcUrl.trim() &&
+            (formMethods.formState.isValid ? <>YES</> : <>NO</>)}
+          {isCheckingRPC && <Spinner className='absolute left-0 right-0 mx-auto' />}
+        </Button>
+        <TrashIcon
+          onClick={() => {
+            remove(chainId)
+            formMethods.setValue('rpc', '')
+            setCheckedRpcUrl('')
+          }}
+          className='h-5 w-5 text-pt-purple-200 cursor-pointer'
+        />
+      </form>
+    </FormProvider>
+  )
+}

--- a/shared/react-components/components/Modals/SettingsModal/index.tsx
+++ b/shared/react-components/components/Modals/SettingsModal/index.tsx
@@ -17,6 +17,7 @@ export type SettingsModalView = 'menu' | SettingsModalOption
 export interface SettingsModalProps {
   view: SettingsModalView
   setView: (view: SettingsModalView) => void
+  reloadPage: () => void
   locales?: LANGUAGE_ID[]
   localVaultLists: { [id: string]: VaultList }
   supportedNetworks?: NETWORK[]
@@ -52,6 +53,7 @@ export const SettingsModal = (props: SettingsModalProps) => {
   const {
     view,
     setView,
+    reloadPage,
     locales,
     localVaultLists,
     supportedNetworks,
@@ -81,7 +83,7 @@ export const SettingsModal = (props: SettingsModalProps) => {
     vaultLists: (
       <VaultListView localVaultLists={localVaultLists} onSuccess={onVaultListImport} intl={intl} />
     ),
-    customRPCs: <RPCsView chainIds={supportedNetworks ?? []} />
+    customRPCs: <RPCsView chainIds={supportedNetworks ?? []} onClickPageReload={reloadPage} />
   }
 
   if (isModalOpen) {

--- a/shared/react-components/components/Modals/SettingsModal/index.tsx
+++ b/shared/react-components/components/Modals/SettingsModal/index.tsx
@@ -2,13 +2,15 @@ import { ArrowLeftIcon } from '@heroicons/react/24/outline'
 import { CURRENCY_ID, LANGUAGE_ID, MODAL_KEYS, useIsModalOpen } from '@shared/generic-react-hooks'
 import { Intl, VaultList } from '@shared/types'
 import { Modal } from '@shared/ui'
+import { NETWORK } from '@shared/utilities'
 import { ReactNode } from 'react'
 import { CurrencyView } from './Views/CurrencyView'
 import { LanguageView } from './Views/LanguageView'
 import { MenuView } from './Views/MenuView'
+import { RPCsView } from './Views/RPCsView'
 import { VaultListView } from './Views/VaultListView'
 
-export type SettingsModalOption = 'currency' | 'language' | 'vaultLists'
+export type SettingsModalOption = 'currency' | 'language' | 'vaultLists' | 'customRPCs'
 
 export type SettingsModalView = 'menu' | SettingsModalOption
 
@@ -17,6 +19,7 @@ export interface SettingsModalProps {
   setView: (view: SettingsModalView) => void
   locales?: LANGUAGE_ID[]
   localVaultLists: { [id: string]: VaultList }
+  supportedNetworks?: NETWORK[]
   disable?: SettingsModalOption[]
   hide?: SettingsModalOption[]
   onCurrencyChange?: (id: CURRENCY_ID) => void
@@ -51,6 +54,7 @@ export const SettingsModal = (props: SettingsModalProps) => {
     setView,
     locales,
     localVaultLists,
+    supportedNetworks,
     disable,
     hide,
     onCurrencyChange,
@@ -76,7 +80,8 @@ export const SettingsModal = (props: SettingsModalProps) => {
     ),
     vaultLists: (
       <VaultListView localVaultLists={localVaultLists} onSuccess={onVaultListImport} intl={intl} />
-    )
+    ),
+    customRPCs: <RPCsView chainIds={supportedNetworks ?? []} />
   }
 
   if (isModalOpen) {

--- a/shared/react-components/components/Modals/SettingsModal/index.tsx
+++ b/shared/react-components/components/Modals/SettingsModal/index.tsx
@@ -35,6 +35,7 @@ export interface SettingsModalProps {
       | 'changeLanguage'
       | 'viewEcosystem'
       | 'manageVaultLists'
+      | 'setCustomRPCs'
       | 'getHelp'
       | 'getHelpWithCabana'
       | 'vaultListsDescription'
@@ -44,8 +45,19 @@ export interface SettingsModalProps {
       | 'clearImportedVaultLists'
       | 'numTokens'
       | 'imported'
+      | 'customRpcDescription'
+      | 'customNetworkRpc'
+      | 'override'
+      | 'default'
+      | 'set'
+      | 'refreshToUpdateRPCs'
     >
-    errors?: Intl<'formErrors.invalidSrc' | 'formErrors.invalidVaultList'>
+    errors?: Intl<
+      | 'formErrors.invalidSrc'
+      | 'formErrors.invalidVaultList'
+      | 'formErrors.invalidRpcNetwork'
+      | 'formErrors.invalidRpcUrl'
+    >
   }
 }
 
@@ -83,7 +95,9 @@ export const SettingsModal = (props: SettingsModalProps) => {
     vaultLists: (
       <VaultListView localVaultLists={localVaultLists} onSuccess={onVaultListImport} intl={intl} />
     ),
-    customRPCs: <RPCsView chainIds={supportedNetworks ?? []} onClickPageReload={reloadPage} />
+    customRPCs: (
+      <RPCsView chainIds={supportedNetworks ?? []} onClickPageReload={reloadPage} intl={intl} />
+    )
   }
 
   if (isModalOpen) {


### PR DESCRIPTION
This PR adds functionality to the main app's settings modal to allow inputing custom RPCs for any network being used.

These RPC URLs are stored locally on the browser and can be easily reset.