### PR TITLE
docs: add lottie issue resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,4 +127,4 @@ The biggest culprit of the above is `@tanstack/react-query`, which sometimes is 
 
 If editing component themes in `ui`, having the `Tailwind CSS IntelliSense` plugin for VSCode is recommended. In order to enable it for custom Flowbite themes and string class names, add `theme` and `.*ClassName*` to the `Class Attributes` setting.
 
-Currently,  `lottie-react` has some issues SSR in Node v22. See this [Github issue](https://github.com/Gamote/lottie-react/issues/101#issuecomment-2196496874). If you run into an errors similar to that (i.e `ReferenceError: document is not defined`), downgrad your node version to 18 (Ref: https://github.com/Gamote/lottie-react/issues/101#issuecomment-2196496874)
+Currently, `lottie-react` has some SSR issues in Node v22 as seen [here](https://github.com/Gamote/lottie-react/issues/101). Downgrading your node version to v18 resolves this issue.

--- a/README.md
+++ b/README.md
@@ -126,3 +126,5 @@ When adding/updating apps and/or packages, duplicate dependencies may be created
 The biggest culprit of the above is `@tanstack/react-query`, which sometimes is installed as two different versions and apps can no longer utilize hooks from the hooks package. This has been solved through the method described [here](https://github.com/TanStack/query/issues/3595#issuecomment-1248074333).
 
 If editing component themes in `ui`, having the `Tailwind CSS IntelliSense` plugin for VSCode is recommended. In order to enable it for custom Flowbite themes and string class names, add `theme` and `.*ClassName*` to the `Class Attributes` setting.
+
+Currently,  `lottie-react` has some issues SSR in Node v22. See this [Github issue](https://github.com/Gamote/lottie-react/issues/101#issuecomment-2196496874). If you run into an errors similar to that (i.e `ReferenceError: document is not defined`), downgrad your node version to 18 (Ref: https://github.com/Gamote/lottie-react/issues/101#issuecomment-2196496874)


### PR DESCRIPTION
I had some issues setting this up. Apparently `lottie-react` doesn't work properly SSR in Node v22 which I use. I found it only works normally on version 18 [https://github.com/Gamote/lottie-react/issues/101](https://github.com/Gamote/lottie-react/issues/101). 

Updated the docs to state that for anyone who might want to try setting the repo and run into same issue