### PR TITLE
EIP 7677 Separation

### DIFF
--- a/apps/app/messages/en.json
+++ b/apps/app/messages/en.json
@@ -318,6 +318,10 @@
       "disabled": "Permit approvals are disabled"
     },
     "eip5792": {
+      "enabled": "Batched transactions are enabled",
+      "disabled": "Batched transactions are disabled"
+    },
+    "eip7677": {
       "enabled": "Gasless transactions are enabled",
       "disabled": "Gasless transactions are disabled"
     }

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3000",

--- a/apps/app/src/components/Account/AccountPromotionsHeader.tsx
+++ b/apps/app/src/components/Account/AccountPromotionsHeader.tsx
@@ -10,7 +10,7 @@ import { useAddRecentTransaction, useChainModal, useConnectModal } from '@rainbo
 import { useMiscSettings } from '@shared/generic-react-hooks'
 import { CurrencyValue, TransactionButton } from '@shared/react-components'
 import { Spinner } from '@shared/ui'
-import { getNiceNetworkNameByChainId, supportsEip5792 } from '@shared/utilities'
+import { getNiceNetworkNameByChainId, supportsEip5792, supportsEip7677 } from '@shared/utilities'
 import classNames from 'classnames'
 import { useTranslations } from 'next-intl'
 import { useMemo } from 'react'
@@ -181,16 +181,22 @@ const ClaimAllRewardsButton = (props: ClaimAllRewardsButtonProps) => {
   )
 
   const { data: walletCapabilities } = useCapabilities()
+  const chainWalletCapabilities = walletCapabilities?.[chainId] ?? {}
+
   const { isActive: isEip5792Disabled } = useMiscSettings('eip5792Disabled')
-  const isUsingEip5792 = supportsEip5792(walletCapabilities?.[chainId] ?? {}) && !isEip5792Disabled
+  const isUsingEip5792 = supportsEip5792(chainWalletCapabilities) && !isEip5792Disabled
+
+  const { isActive: isEip7677Disabled } = useMiscSettings('eip7677Disabled')
   const paymasterUrl = PAYMASTER_URLS[chainId]
+  const isUsingEip7677 =
+    !!paymasterUrl && supportsEip7677(chainWalletCapabilities) && !isEip7677Disabled
 
   const data5792ClaimRewardsTx = useSend5792ClaimRewardsTransaction(
     chainId,
     userAddress,
     epochsToClaim,
     {
-      paymasterService: !!paymasterUrl ? { url: paymasterUrl, optional: true } : undefined,
+      paymasterService: isUsingEip7677 ? { url: paymasterUrl, optional: true } : undefined,
       onSuccess: () => {
         refetchAllClaimed()
         refetchAllClaimable()
@@ -204,7 +210,7 @@ const ClaimAllRewardsButton = (props: ClaimAllRewardsButtonProps) => {
     userAddress,
     poolWidePromotionsToClaim,
     {
-      paymasterService: !!paymasterUrl ? { url: paymasterUrl, optional: true } : undefined,
+      paymasterService: isUsingEip7677 ? { url: paymasterUrl, optional: true } : undefined,
       onSuccess: () => {
         refetchAllPoolWideClaimed()
         refetchAllPoolWideClaimable()
@@ -219,7 +225,7 @@ const ClaimAllRewardsButton = (props: ClaimAllRewardsButtonProps) => {
     epochsToClaim,
     poolWidePromotionsToClaim,
     {
-      paymasterService: !!paymasterUrl ? { url: paymasterUrl, optional: true } : undefined,
+      paymasterService: isUsingEip7677 ? { url: paymasterUrl, optional: true } : undefined,
       onSuccess: () => {
         refetchAllClaimed()
         refetchAllClaimable()

--- a/apps/app/src/components/Modals/DelegateModal/DelegateTxButton.tsx
+++ b/apps/app/src/components/Modals/DelegateModal/DelegateTxButton.tsx
@@ -8,7 +8,7 @@ import {
 import { useAddRecentTransaction, useChainModal, useConnectModal } from '@rainbow-me/rainbowkit'
 import { useMiscSettings } from '@shared/generic-react-hooks'
 import { TransactionButton } from '@shared/react-components'
-import { supportsEip5792 } from '@shared/utilities'
+import { supportsEip5792, supportsEip7677 } from '@shared/utilities'
 import { useAtomValue } from 'jotai'
 import { useTranslations } from 'next-intl'
 import { useEffect } from 'react'
@@ -63,13 +63,18 @@ export const DelegateTxButton = (props: DelegateTxButtonProps) => {
   })
 
   const { data: walletCapabilities } = useCapabilities()
+  const chainWalletCapabilities = walletCapabilities?.[vault.chainId] ?? {}
+
   const { isActive: isEip5792Disabled } = useMiscSettings('eip5792Disabled')
-  const isUsingEip5792 =
-    supportsEip5792(walletCapabilities?.[vault.chainId] ?? {}) && !isEip5792Disabled
+  const isUsingEip5792 = supportsEip5792(chainWalletCapabilities) && !isEip5792Disabled
+
+  const { isActive: isEip7677Disabled } = useMiscSettings('eip7677Disabled')
   const paymasterUrl = PAYMASTER_URLS[vault.chainId]
+  const isUsingEip7677 =
+    !!paymasterUrl && supportsEip7677(chainWalletCapabilities) && !isEip7677Disabled
 
   const data5792Tx = useSend5792DelegateTransaction(twabController, newDelegateAddress, vault, {
-    paymasterService: !!paymasterUrl ? { url: paymasterUrl, optional: true } : undefined,
+    paymasterService: isUsingEip7677 ? { url: paymasterUrl, optional: true } : undefined,
     onSend: () => {
       setModalView('waiting')
     },

--- a/apps/app/src/components/Modals/DepositModal/DepositTxButton.tsx
+++ b/apps/app/src/components/Modals/DepositModal/DepositTxButton.tsx
@@ -14,7 +14,7 @@ import { useAddRecentTransaction, useChainModal, useConnectModal } from '@rainbo
 import { useMiscSettings } from '@shared/generic-react-hooks'
 import { ApprovalTooltip, TransactionButton } from '@shared/react-components'
 import { Button } from '@shared/ui'
-import { supportsEip5792 } from '@shared/utilities'
+import { supportsEip5792, supportsEip7677 } from '@shared/utilities'
 import { useAtomValue } from 'jotai'
 import { useTranslations } from 'next-intl'
 import { useEffect } from 'react'
@@ -130,13 +130,18 @@ export const DepositTxButton = (props: DepositTxButtonProps) => {
   })
 
   const { data: walletCapabilities } = useCapabilities()
+  const chainWalletCapabilities = walletCapabilities?.[vault.chainId] ?? {}
+
   const { isActive: isEip5792Disabled } = useMiscSettings('eip5792Disabled')
-  const isUsingEip5792 =
-    supportsEip5792(walletCapabilities?.[vault.chainId] ?? {}) && !isEip5792Disabled
+  const isUsingEip5792 = supportsEip5792(chainWalletCapabilities) && !isEip5792Disabled
+
+  const { isActive: isEip7677Disabled } = useMiscSettings('eip7677Disabled')
   const paymasterUrl = PAYMASTER_URLS[vault.chainId]
+  const isUsingEip7677 =
+    !!paymasterUrl && supportsEip7677(chainWalletCapabilities) && !isEip7677Disabled
 
   const data5792DepositTx = useSend5792DepositTransaction(depositAmount, vault, {
-    paymasterService: !!paymasterUrl ? { url: paymasterUrl, optional: true } : undefined,
+    paymasterService: isUsingEip7677 ? { url: paymasterUrl, optional: true } : undefined,
     onSend: () => {
       setModalView('waiting')
     },

--- a/apps/app/src/components/Modals/DepositModal/DepositZapTxButton.tsx
+++ b/apps/app/src/components/Modals/DepositModal/DepositZapTxButton.tsx
@@ -15,7 +15,13 @@ import { useAddRecentTransaction, useChainModal, useConnectModal } from '@rainbo
 import { useMiscSettings } from '@shared/generic-react-hooks'
 import { ApprovalTooltip, TransactionButton } from '@shared/react-components'
 import { Button } from '@shared/ui'
-import { DOLPHIN_ADDRESS, lower, supportsEip5792, ZAP_SETTINGS } from '@shared/utilities'
+import {
+  DOLPHIN_ADDRESS,
+  lower,
+  supportsEip5792,
+  supportsEip7677,
+  ZAP_SETTINGS
+} from '@shared/utilities'
 import { useAtomValue } from 'jotai'
 import { useTranslations } from 'next-intl'
 import { useEffect } from 'react'
@@ -149,10 +155,15 @@ export const DepositZapTxButton = (props: DepositZapTxButtonProps) => {
   )
 
   const { data: walletCapabilities } = useCapabilities()
+  const chainWalletCapabilities = walletCapabilities?.[vault.chainId] ?? {}
+
   const { isActive: isEip5792Disabled } = useMiscSettings('eip5792Disabled')
-  const isUsingEip5792 =
-    supportsEip5792(walletCapabilities?.[vault.chainId] ?? {}) && !isEip5792Disabled
+  const isUsingEip5792 = supportsEip5792(chainWalletCapabilities) && !isEip5792Disabled
+
+  const { isActive: isEip7677Disabled } = useMiscSettings('eip7677Disabled')
   const paymasterUrl = PAYMASTER_URLS[vault.chainId]
+  const isUsingEip7677 =
+    !!paymasterUrl && supportsEip7677(chainWalletCapabilities) && !isEip7677Disabled
 
   const data5792Tx = useSend5792DepositZapTransaction(
     {
@@ -162,7 +173,7 @@ export const DepositZapTxButton = (props: DepositZapTxButtonProps) => {
     },
     vault,
     {
-      paymasterService: !!paymasterUrl ? { url: paymasterUrl, optional: true } : undefined,
+      paymasterService: isUsingEip7677 ? { url: paymasterUrl, optional: true } : undefined,
       onSend: () => {
         setModalView('waiting')
       },

--- a/apps/app/src/components/Modals/SettingsModal/Views/MiscSettingsView.tsx
+++ b/apps/app/src/components/Modals/SettingsModal/Views/MiscSettingsView.tsx
@@ -12,6 +12,9 @@ export const MiscSettingsView = () => {
   const { isActive: isEip5792Disabled, set: setIsEip5792Disabled } =
     useMiscSettings('eip5792Disabled')
 
+  const { isActive: isEip7677Disabled, set: setIsEip7677Disabled } =
+    useMiscSettings('eip7677Disabled')
+
   return (
     <div className='flex flex-col items-center gap-6'>
       <span className='text-lg font-semibold text-pt-purple-50 md:text-xl'>
@@ -29,6 +32,12 @@ export const MiscSettingsView = () => {
         checkedContent={t('eip5792.enabled')}
         uncheckedContent={t('eip5792.disabled')}
         isChecked={!isEip5792Disabled}
+      />
+      <SettingToggle
+        onChange={(checked) => setIsEip7677Disabled(!checked)}
+        checkedContent={t('eip7677.enabled')}
+        uncheckedContent={t('eip7677.disabled')}
+        isChecked={!isEip7677Disabled}
       />
     </div>
   )

--- a/apps/app/src/components/Modals/WithdrawModal/WithdrawTxButton.tsx
+++ b/apps/app/src/components/Modals/WithdrawModal/WithdrawTxButton.tsx
@@ -14,7 +14,7 @@ import { useAddRecentTransaction, useChainModal, useConnectModal } from '@rainbo
 import { useMiscSettings } from '@shared/generic-react-hooks'
 import { TransactionButton } from '@shared/react-components'
 import { Button } from '@shared/ui'
-import { supportsEip5792 } from '@shared/utilities'
+import { supportsEip5792, supportsEip7677 } from '@shared/utilities'
 import { useAtomValue } from 'jotai'
 import { useTranslations } from 'next-intl'
 import { useEffect } from 'react'
@@ -114,14 +114,19 @@ export const WithdrawTxButton = (props: WithdrawTxButtonProps) => {
   })
 
   const { data: walletCapabilities } = useCapabilities()
+  const chainWalletCapabilities = walletCapabilities?.[vault.chainId] ?? {}
+
   const { isActive: isEip5792Disabled } = useMiscSettings('eip5792Disabled')
-  const isUsingEip5792 =
-    supportsEip5792(walletCapabilities?.[vault.chainId] ?? {}) && !isEip5792Disabled
+  const isUsingEip5792 = supportsEip5792(chainWalletCapabilities) && !isEip5792Disabled
+
+  const { isActive: isEip7677Disabled } = useMiscSettings('eip7677Disabled')
   const paymasterUrl = PAYMASTER_URLS[vault.chainId]
+  const isUsingEip7677 =
+    !!paymasterUrl && supportsEip7677(chainWalletCapabilities) && !isEip7677Disabled
 
   const data5792Tx = useSend5792RedeemTransaction(withdrawAmount, vault, {
     minAssets: expectedAssetAmount,
-    paymasterService: !!paymasterUrl ? { url: paymasterUrl, optional: true } : undefined,
+    paymasterService: isUsingEip7677 ? { url: paymasterUrl, optional: true } : undefined,
     onSend: () => {
       setModalView('waiting')
     },

--- a/apps/app/src/components/Modals/WithdrawModal/WithdrawZapTxButton.tsx
+++ b/apps/app/src/components/Modals/WithdrawModal/WithdrawZapTxButton.tsx
@@ -17,7 +17,7 @@ import { useAddRecentTransaction, useChainModal, useConnectModal } from '@rainbo
 import { useMiscSettings } from '@shared/generic-react-hooks'
 import { ApprovalTooltip, TransactionButton } from '@shared/react-components'
 import { Button } from '@shared/ui'
-import { supportsEip5792, ZAP_SETTINGS } from '@shared/utilities'
+import { supportsEip5792, supportsEip7677, ZAP_SETTINGS } from '@shared/utilities'
 import { useAtomValue } from 'jotai'
 import { useTranslations } from 'next-intl'
 import { useEffect } from 'react'
@@ -149,17 +149,22 @@ export const WithdrawZapTxButton = (props: WithdrawZapTxButtonProps) => {
   )
 
   const { data: walletCapabilities } = useCapabilities()
+  const chainWalletCapabilities = walletCapabilities?.[vault.chainId] ?? {}
+
   const { isActive: isEip5792Disabled } = useMiscSettings('eip5792Disabled')
-  const isUsingEip5792 =
-    supportsEip5792(walletCapabilities?.[vault.chainId] ?? {}) && !isEip5792Disabled
+  const isUsingEip5792 = supportsEip5792(chainWalletCapabilities) && !isEip5792Disabled
+
+  const { isActive: isEip7677Disabled } = useMiscSettings('eip7677Disabled')
   const paymasterUrl = PAYMASTER_URLS[vault.chainId]
+  const isUsingEip7677 =
+    !!paymasterUrl && supportsEip7677(chainWalletCapabilities) && !isEip7677Disabled
 
   const data5792Tx = useSend5792WithdrawZapTransaction(
     { address: outputToken?.address!, decimals: outputToken?.decimals! },
     vault,
     withdrawAmount,
     {
-      paymasterService: !!paymasterUrl ? { url: paymasterUrl, optional: true } : undefined,
+      paymasterService: isUsingEip7677 ? { url: paymasterUrl, optional: true } : undefined,
       onSend: () => {
         setModalView('waiting')
       },

--- a/shared/utilities/utils/eip5792.ts
+++ b/shared/utilities/utils/eip5792.ts
@@ -6,9 +6,14 @@ import { GetCapabilitiesReturnType } from 'viem'
  * @returns
  */
 export const supportsEip5792 = (capabilities: GetCapabilitiesReturnType[number]) => {
-  return (
-    capabilities.atomic?.status === 'supported' ||
-    capabilities.atomic?.status === 'ready' ||
-    !!capabilities.paymasterService?.supported
-  )
+  return capabilities.atomic?.status === 'supported' || capabilities.atomic?.status === 'ready'
+}
+
+/**
+ * Returns `true` if a wallet supports EIP 7677
+ * @param capabilities the wallet capabilities for a specific network
+ * @returns
+ */
+export const supportsEip7677 = (capabilities: GetCapabilitiesReturnType[number]) => {
+  return !!capabilities.paymasterService?.supported
 }


### PR DESCRIPTION
This PR separates the implementation of EIP 5792 and EIP 7677 in the Cabana App, conditionally applying each based on a wallet's response in terms of its capabilities.

This should handle a few edge cases, but some wallets are still out of spec and would require some updates to work.